### PR TITLE
Updated use of singleton to ensure classes get used

### DIFF
--- a/includes/classes/MailCatcher/MailCatcher.php
+++ b/includes/classes/MailCatcher/MailCatcher.php
@@ -16,9 +16,10 @@ use PHPMailer\PHPMailer\PHPMailer;
  * Disables all emails from being sent and instead
  * routes to a local mailcatcher instance if available.
  */
-class MailCatcher extends Singleton {
+class MailCatcher {
 
 	use Environment;
+	use Singleton;
 
 	/**
 	 * SMTP hostname or IP

--- a/includes/classes/RemoteFiles/RemoteFiles.php
+++ b/includes/classes/RemoteFiles/RemoteFiles.php
@@ -16,9 +16,10 @@ use Roots\WPConfig\Exceptions\UndefinedConfigKeyException;
  * This class is built upon BE Media from Production so all due credit to those authors.
  * http://www.github.com/billerickson/be-media-from-production
  */
-class RemoteFiles extends Singleton {
+class RemoteFiles {
 
 	use Environment;
+	use Singleton;
 
 	/**
 	 * Production URL

--- a/includes/classes/Singleton.php
+++ b/includes/classes/Singleton.php
@@ -1,34 +1,46 @@
 <?php
 /**
- * Singleton definition for this plugin's classes
+ * Singleton trait
  *
  * @package Satellite
  */
 
 namespace Eighteen73\Satellite;
 
-/**
- * Abstract class
- */
-abstract class Singleton {
+trait Singleton {
+
 	/**
-	 * Return instance of class
+	 * The class instance
 	 *
-	 * @return self
+	 * @var self|null
 	 */
-	public static function instance(): Singleton {
-		static $instance;
+	private static $instance = null;
 
-		if ( empty( $instance ) ) {
-			$class = get_called_class();
-
-			$instance = new $class();
-
-			if ( method_exists( $instance, 'setup' ) ) {
-				$instance->setup();
-			}
+	/**
+	 * Get the current instance
+	 *
+	 * @return Singleton
+	 */
+	final public static function instance(): self {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
 		}
+		return self::$instance;
+	}
 
-		return $instance;
+	/**
+	 * Constructor
+	 */
+	private function __construct() {
+		// Intentionally empty
+	}
+
+	/**
+	 * Class clone
+	 *
+	 * @return void
+	 */
+	private function __clone() {
+		// Intentionally empty
 	}
 }


### PR DESCRIPTION
After some investigation I found that the MailCatcher class wasn't actually being activated, i noticed that the implementation of the singleton class was different to Orbit, when I replicated this within satellite the setup functions got called properly and the mailcatcher started working again.